### PR TITLE
Update OsmPbfParser.scala

### DIFF
--- a/src/main/scala/io/plasmap/parser/impl/OsmPbfParser.scala
+++ b/src/main/scala/io/plasmap/parser/impl/OsmPbfParser.scala
@@ -10,8 +10,10 @@ import io.plasmap.parser.OsmParser
 import pbfbinaryparser.genclasses.Osmformat.{Relation, Node,DenseNodes, PrimitiveGroup, Way}
 import pbfbinaryparser.genclasses.{Osmformat, Fileformat}
 import java.util.zip.InflaterInputStream
+import shapeless.HList
+
 import scala.annotation.tailrec
-import scala.collection.{mutable}
+import scala.collection.mutable
 
 import java.io.{DataInputStream, File, FileInputStream}
 
@@ -23,9 +25,8 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
   val dis: DataInputStream = reachFirstBlob(fileName)
   val osmObjects = mutable.Queue[Option[OsmObject]]()
 
-  override def hasNext(): Boolean ={
+  override def hasNext: Boolean =
     dis.available() != 0 || osmObjects.nonEmpty
-  }
 
   override def next(): Option[OsmObject] = {
     if( osmObjects.isEmpty )
@@ -39,7 +40,7 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
     val bhSize: Int = dis.readInt
     val rawBH: Array[Byte] = new Array[Byte](bhSize)
     dis.read(rawBH)
-    var bh: Fileformat.BlobHeader = Fileformat.BlobHeader.parseFrom(rawBH)
+    val bh: Fileformat.BlobHeader = Fileformat.BlobHeader.parseFrom(rawBH)
     val blobSize = bh.getDatasize
 
     val rawBlob = new Array[Byte](blobSize)
@@ -65,6 +66,8 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
     Fileformat.Blob.parseFrom(rawBlob)
   }
 
+  case class ForTheMaths(latOffset:Long, lonOffset:Long, geoGranularity:Int, dateGranularity:Int)
+
   def repopulateQueue(queue: mutable.Queue[Option[OsmObject]], dis: DataInputStream): Unit = {
     val pb = uncompressBlob( nextBlob(dis) )
 
@@ -72,11 +75,7 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
     val stringTable = pb.getStringtable.getSList.asScala.map(_.toStringUtf8).toArray
 
     //Necessary to compute a geographical data from the raw lat and lon values of the files + same for the date
-    val forTheMaths = Map(
-      "latOffset" -> pb.getLatOffset,
-      "lonOffset" -> pb.getLonOffset,
-      "geoGranularity" -> pb.getGranularity.toLong,
-      "dateGranularity" -> pb.getDateGranularity.toLong)
+    val forTheMaths = ForTheMaths(pb.getLatOffset, pb.getLonOffset, pb.getGranularity, pb.getDateGranularity)
 
 
     val primitiveGroups = pb.getPrimitivegroupList.asScala
@@ -103,36 +102,36 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
   }
 
   def uncompressBlob( blob: Fileformat.Blob): Osmformat.PrimitiveBlock = {
-      val decompresser = new InflaterInputStream (blob.getZlibData ().newInput () )
-      val pb = Osmformat.PrimitiveBlock.parseFrom (decompresser)
-      decompresser.close ()
+      val unpacker = new InflaterInputStream (blob.getZlibData.newInput() )
+      val pb = Osmformat.PrimitiveBlock.parseFrom (unpacker)
+      unpacker.close()
       pb
   }
 
   def getWays(stringTable: Array[String], way: Way): OsmWay = {
-    val id = new OsmId( way.getId )
+    val id = OsmId( way.getId )
     val osmTags = List(
       way.getKeysList.asScala,
       way.getValsList.asScala
     )
       .transpose
-      .map( t  => new OsmTag(stringTable(t(0).asInstanceOf[Int] ), stringTable(t(1).asInstanceOf[Int]) ) )
+      .map( t  => OsmTag(stringTable(t(0).asInstanceOf[Int] ), stringTable(t(1).asInstanceOf[Int]) ) )
 
-    val osmRefs = valFromDelta( way.getRefsList.asScala.toList ).map(new OsmId(_))
-    val user = new OsmUser( stringTable( way.getInfo.getUserSid ), way.getInfo.getUid)
+    val osmRefs = valFromDelta( way.getRefsList.asScala.toList ).map(OsmId)
+    val user = OsmUser( stringTable( way.getInfo.getUserSid ), way.getInfo.getUid)
     val version = way.getInfo.getVersion
 
-    new OsmWay( id, Option(user), new OsmVersion(version), osmTags, osmRefs)
+    OsmWay( id, Option(user), OsmVersion(version), osmTags, osmRefs)
   }
 
   def getRelations(stringTable: Array[String], relation: Relation): OsmRelation = {
-    val osmId = new OsmId(relation.getId)
-    val osmUser = new OsmUser( stringTable( relation.getInfo.getUserSid ), relation.getInfo.getUid )
-    val osmVersion = new OsmVersion(  relation.getInfo.getVersion )
+    val osmId = OsmId(relation.getId)
+    val osmUser = OsmUser( stringTable( relation.getInfo.getUserSid ), relation.getInfo.getUid )
+    val osmVersion = OsmVersion(  relation.getInfo.getVersion )
     val osmTags =
       List( relation.getKeysList.asScala.toList, relation.getValsList.asScala )
       .transpose
-      .map( t  => new OsmTag(stringTable(t(0).asInstanceOf[Int] ), stringTable(t(1).asInstanceOf[Int]) ) )
+      .map( t  => OsmTag(stringTable(t(0).asInstanceOf[Int] ), stringTable(t(1).asInstanceOf[Int]) ) )
 
     def getOsmType( sType : Int ): OsmType = stringTable(sType) match {
       case "way"      => OsmTypeWay
@@ -144,67 +143,77 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
       case "inner" => OsmRoleInner
       case "outer" => OsmRoleOuter
       case ""      => OsmRoleEmpty
-      case r       => new OsmRoleOther(r)
+      case r       => OsmRoleOther(r)
     }
+
     val osmMembers = List(
-      relation.getTypesList.asScala.map( x => new java.lang.Integer(x.getNumber) ),
-      valFromDelta( relation.getMemidsList.asScala.toList ),
+      relation.getTypesList.asScala.map(_.getNumber),
+      valFromDelta(relation.getMemidsList.asScala.toList),
       relation.getRolesSidList.asScala
     )
       .transpose
-      .map( m => new OsmMember(
-          getOsmType(m(0).asInstanceOf[Integer]),
-          new OsmId(m(1).asInstanceOf[Long]),
+      .map( m => OsmMember(
+          getOsmType(m(0).asInstanceOf[Int]),
+          OsmId(m(1).asInstanceOf[Long]),
           getOsmRole( m(2).asInstanceOf[Int])
         )
       )
 
-    new OsmRelation(osmId, Option(osmUser), osmVersion, osmTags, osmMembers)
+    OsmRelation(osmId, Option(osmUser), osmVersion, osmTags, osmMembers)
   }
 
-  def getSingleNode(stringTable: Array[String], forTheMaths: Map[String,Long], node: Node): OsmNode = {
-    val osmId = new OsmId(node.getId)
-    val osmUser = new OsmUser( stringTable( node.getInfo.getUserSid ), node.getInfo.getUid )
-    val osmVersion = new OsmVersion(  node.getInfo.getVersion )
+  def coordinate(geoGran:Int)(pos:Long, offset:Long):Double = {
+    val scaleFactor:Double = 0.000000001
+    (pos * geoGran + offset) * scaleFactor
+  }
+
+
+  def getSingleNode(stringTable: Array[String], forTheMaths: ForTheMaths, node: Node): OsmNode = {
+    val osmId = OsmId(node.getId)
+    val osmUser = OsmUser( stringTable( node.getInfo.getUserSid ), node.getInfo.getUid )
+    val osmVersion = OsmVersion(  node.getInfo.getVersion )
 
     val osmTags =
       List( valFromDelta(node.getKeysList.asScala.toList), valFromDelta(node.getValsList.asScala.toList) )
       .transpose
-      .map( t  => new OsmTag(stringTable(t(0).asInstanceOf[Int] ), stringTable(t(1).asInstanceOf[Int]) ) )
+      .map( t  => OsmTag(stringTable(t(0).asInstanceOf[Int] ), stringTable(t(1).asInstanceOf[Int]) ) )
 
-    val latOffset = forTheMaths("latOffset")
-    val lonOffset = forTheMaths("lonOffset")
-    val geoGran = forTheMaths("geoGranularity")
+    val latOffset: Long = forTheMaths.latOffset
+    val lonOffset: Long = forTheMaths.lonOffset
+    val geoGran: Int = forTheMaths.geoGranularity
 
-    val lat = node.getLat
-    val lon = node.getLon
-    val geoPoint = Point(
-      0.000000001 * (latOffset + (geoGran * lat)),
-      0.000000001 * (lonOffset + (geoGran * lon))
-    )
+    def c = coordinate(geoGran) _
 
-    new OsmNode(osmId, Option(osmUser), osmVersion, osmTags, geoPoint )
+    val lon = c(node.getLon, lonOffset)
+    val lat = c(node.getLat, latOffset)
+    val geoPoint = Point(lon, lat)
+
+    OsmNode(osmId, Option(osmUser), osmVersion, osmTags, geoPoint )
   }
 
-  def getDenseNodes( stringTable : Array[String], forTheMaths: Map[String,Long], dns : DenseNodes): List[OsmNode] ={
-    val valIds = valFromDelta(dns.getIdList.asScala.toList)
-    val tags = getTagsNodeIds(dns.getKeysValsList.asScala.toList, valIds)
+  def getDenseNodes( stringTable:Array[String], forTheMaths:ForTheMaths, dns:DenseNodes): List[OsmNode] ={
+    val valIds: List[Long] = valFromDelta(dns.getIdList.asScala.toList)
+    val tags: List[(Int, Int, Long)] = getTagsNodeIds(dns.getKeysValsList.asScala.toList.map(_.toInt), valIds)
 
-    val latOffset = forTheMaths("latOffset")
-    val lonOffset = forTheMaths("lonOffset")
-    val geoGran = forTheMaths("geoGranularity")
-    val dateGran = forTheMaths("dateGranularity")
+    val latOffset: Long = forTheMaths.latOffset
+    val lonOffset: Long = forTheMaths.lonOffset
+    val geoGran: Int = forTheMaths.geoGranularity
+    val dateGran: Int = forTheMaths.dateGranularity
 
-    val grouped: List[(Long, List[(Integer, Integer, Long)])] =
+
+    val grouped: List[(Long, List[(Int, Int, Long)])] =
       tags
         .groupBy({case (key, v, id) => id})
         .toList
         .sortWith( (x,y) => x._1.compareTo(y._1) < 0 )
 
-    val nodes = List(
+    def c = coordinate(geoGran) _
+
+    //TODO: This is not nice. There's no reason for Any to be here. This can be inside of a data structure
+    val nodes: List[List[Any]] = List(
       grouped,
-      valFromDelta(dns.getLatList.asScala.toList).map( (lat : Long) => 0.000000001 * (latOffset + (geoGran * lat))),
-      valFromDelta(dns.getLonList.asScala.toList).map( (lon : Long) => 0.000000001 * (lonOffset + (geoGran * lon))),
+      valFromDelta(dns.getLonList.asScala.toList).map( (lon : Long) => c(lon, lonOffset)),
+      valFromDelta(dns.getLatList.asScala.toList).map( (lat : Long) => c(lat, latOffset)),
       valFromDelta(dns.getDenseinfo.getChangesetList.asScala.toList),
       valFromDelta(dns.getDenseinfo.getTimestampList.asScala.toList).map( (ts : Long) => ts * dateGran),
       valFromDelta(dns.getDenseinfo.getUidList.asScala.toList),
@@ -212,11 +221,21 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
       dns.getDenseinfo.getVersionList.asScala.map(_.longValue())
     ).transpose
 
+    //TODO: I really don't like this. I propose making a function that returns an Option of a case class.
+    //All the casting is bad enough. It should be wrapped inside of a Try.
+    //Somewhat like this:
+    //case class AlmostOsmNode(id:Long, tags:List[(String, String, Long)],....)
+    //for {
+    //  id ← Try(xyz.asInstanceOf[Double]).toOption.map(_._1)
+    //  tags ← Try(uvw.asInstanceOf[(Long...]).toOption.map(_.2).map(_.map(kvid: (Int, Int, Long))
+    // ...
+    // } yield AlmostOsmNode(id, tags, ...)
+    // So basically wrap anything that could fail in Try(...).toOption or \/.fromTryCatchNonFatal(...).toOption
     val osmNodes = nodes.map(n => { toOsmNode(
-        n(0).asInstanceOf[(Long, List[(Integer, Integer, Long)])]._1,
-        n(0).asInstanceOf[(Long, List[(Integer, Integer, Long)])]._2.map( (kvid : (Integer,Integer,Long)) => (stringTable(kvid._1), stringTable(kvid._2), kvid._3)),
-        n(1).asInstanceOf[Double],
-        n(2).asInstanceOf[Double],
+        n(0).asInstanceOf[(Long, List[(Int, Int, Long)])]._1,
+        n(0).asInstanceOf[(Long, List[(Int, Int, Long)])]._2.map( (kvid : (Int,Int,Long)) => (stringTable(kvid._1), stringTable(kvid._2), kvid._3)),
+        n(1).asInstanceOf[Double], //lon
+        n(2).asInstanceOf[Double], //lat
         n(3).asInstanceOf[Long],
         n(4).asInstanceOf[Long],
         n(5).asInstanceOf[Long],
@@ -227,38 +246,45 @@ case class OsmPbfParser (fileName: String)  extends OsmParser{
   }
 
   def toOsmNode( id : Long, tags :List[(String,String,Long)], lon : Double, lat: Double, changeSet: Long, timeStamp: Long, uid : Long, user :String, version: Long): OsmNode = {
-    val osmUser = new OsmUser(user, uid)
-    val osmTags = tags.filter(_._1 != None).map( {case (key : String, v :String, id :Long) => new OsmTag(key, v)})
-    val osmId = new OsmId(id)
+    val osmUser = OsmUser(user, uid)
+    val osmTags = tags.filter(_._1 != "").map( {
+      case (key : String, v :String, id :Long) => OsmTag(key, v)
+    })
+    val osmId = OsmId(id)
     val point = Point(lon, lat)
 
-    new OsmNode(osmId, Option(osmUser),new OsmVersion(version),osmTags,point)
+    OsmNode(osmId, Option(osmUser), OsmVersion(version), osmTags, point)
 
   }
 
-  def valFromDelta(l : List[java.lang.Number]): List[Long] = {
-    @tailrec def go( l : List[java.lang.Number] , delta : Long, acc : List[Long]):  List[Long] = l match {
-      case Nil => acc
-      case h :: t => go( t, h.longValue()+ delta, (h.longValue() + delta) :: acc)
-    }
 
-    go(l, 0, List.empty[Long]).reverse
+  def valFromDelta(l : List[Number]): List[Long] = {
+    //Nice implementation of scanLeft
+//    @tailrec
+//    def go( l : List[Number] , delta : Long, acc : List[Long]):  List[Long] = l match {
+//      case Nil => acc
+//      case h :: t =>
+//        val x = h.longValue + delta
+//        go( t, x, x :: acc)
+//    }
+//
+//    go(l, 0, List.empty[Long]).reverse
+    l.scanLeft(0L)( (delta, number) => number.longValue() + delta).tail
   }
   /*
    * Two succeeding integers in the key value list kv represent the key=value pair of a single <tag> element.
    * The value zero in the kv list represent the move to a new node that can contains several tags or none.
    */
-  def getTagsNodeIds( kv : List[Integer], ids: List[Long]): List[(Integer, Integer, Long)] = {
-    @tailrec def go(kv : List[Integer], ids: List[Long], acc :List[(Integer, Integer, Long)]) : List[(Integer, Integer, Long)] = ids.size match {
-      case 0 => acc
-      case _ => kv match {
-        case (h :: t) if h == 0 => go(t, ids.tail,  (new Integer(0), new Integer(0), ids.head) :: acc)
-        case (h :: t) if h != 0 => go(t.tail, ids,  (h, t.head, ids.head) :: acc)
-      }
-
+  def getTagsNodeIds( kv : List[Int], ids: List[Long]): List[(Int, Int, Long)] = {
+    @tailrec
+    def go(kv : List[Int], ids: List[Long], acc :List[(Int, Int, Long)]) : List[(Int, Int, Long)] =
+    if (ids.isEmpty) acc
+    else kv match {
+        case (h :: t) if h == 0 => go(t,      ids.tail,  (0, 0, ids.head) :: acc)
+        case (h :: t) if h != 0 => go(t.tail, ids,       (h, t.head, ids.head) :: acc)
     }
 
-    go(kv, ids, List.empty[Tuple3[Integer, Integer, Long]])
+    go(kv, ids, List.empty[(Int, Int, Long)])
   }
 
 }


### PR DESCRIPTION
Very nice, Jean-Marie. I like your tail recursions and how you are using scala collections instead of the Java rubbish.

There were some bugs. Lon and lat was flipped in some parts. We usually do lon first and then lat. Many sources do it the other way around, though so be careful.
Another bug was the filtering of empty Strings, you had something like .filter(_._1 != None). These aren't even the correct types. A String can't be None. Scalaz === would have caught that, I think. So the correct filter is .filter(_._1 != "").

Further there was this map called forTheMaths, I changed that to a case class, because that's type safe (you could type a key wrong in your code and than have nasty runtime exceptions). Also lookup is constant, I think.

There are some other parts in the code where this refactoring would make sense in my opinion. There are todos for this in the code. 
Have a look at the rest and tell me if I have broken more than I have fixed.

(I did not organise imports... maybe you can do that).